### PR TITLE
docs: align README, CHANGELOG with style guide and add docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Load pre-built USD from `wuji_hand_description/usd/` submodule instead of URDF conversion at runtime
-- Remove `wuji_hand.py` — articulation config inlined in `run_sim.py`, PD gains and collision filters read from USD
-- Add `--side` CLI argument for left/right hand selection (replaces hardcoded `HAND_SIDE`)
-- Update `wuji_hand_description` submodule to v0.2.3 (includes USD assets with PBR materials and collision filter pairs)
+- Replaced URDF runtime conversion with pre-built USD asset loading from submodule
+- Removed standalone hand configuration module; inlined articulation config with PD gains and collision filters read from USD
+- Added `--side` CLI argument for left/right hand selection
+- Updated hand description submodule to v0.2.3 with USD assets, PBR materials, and collision filter pairs
 
 ## [0.1.0] - 2026-02-02
 
 ### Added
 
-- Main simulation script `run_sim.py` for loading and controlling Wuji Hand in IsaacSim
-- Wuji Hand model implementation `wuji_hand.py`
-- Trajectory playback from `data/wave.npy` with loop support
+- Simulation script for loading and controlling Wuji Hand in IsaacSim
+- Trajectory playback with loop support
 - Support for both left and right hand configurations
-- Wuji Hand model as git submodule (`wuji_hand_description/`)
+- Wuji Hand model as git submodule
 
 [Unreleased]: https://github.com/wuji-technology/isaaclab-sim/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/wuji-technology/isaaclab-sim/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/wuji-technology/isaaclab-sim)](https://github.com/wuji-technology/isaaclab-sim/releases)
 
-Simulation demo (IsaacSim): minimal demo for loading and controlling the Wuji Hand in IsaacSim simulator. The script loads the default right hand model and plays the trajectory in a loop. Supports both left and right hand configurations.
+Simulation demo (IsaacSim): minimal demo for loading and controlling the Wuji Hand in IsaacSim simulator. Loads pre-built USD assets with PBR materials and plays trajectory in a loop. Supports both left and right hand configurations via `--side` argument.
 
 https://github.com/user-attachments/assets/2f58ad84-7ed6-46fe-94c1-b4148068bec3
 
@@ -18,22 +18,13 @@ https://github.com/user-attachments/assets/2f58ad84-7ed6-46fe-94c1-b4148068bec3
 ## Repository Structure
 
 ```text
-├── assets/
+├── assets/                        // Demo videos and screenshots
 ├── data/
-│   └── wave.npy
-├── wuji_hand_description/   (submodule: URDF, MJCF, USD, meshes)
-├── run_sim.py
+│   └── wave.npy                   // Pre-recorded trajectory data
+├── wuji_hand_description/         // Submodule: URDF, MJCF, USD, meshes
+├── run_sim.py                     // Main simulation script
 └── README.md
 ```
-
-### Directory Description
-
-| Directory / File | Description |
-|------------------|-------------|
-| `assets/` | Asset files for simulation |
-| `data/` | Trajectory data files including `wave.npy` |
-| `wuji_hand_description/` | Git submodule containing Wuji Hand model descriptions (URDF, MJCF, USD, meshes). USD assets include fused meshes with PBR materials, physics, and collision filter pairs. |
-| `run_sim.py` | Main simulation script. Loads pre-built USD from submodule, no URDF conversion needed. |
 
 ## Usage
 
@@ -55,8 +46,8 @@ python run_sim.py
 python run_sim.py --side left
 ```
 
-The script loads the pre-built USD model from the submodule and plays the trajectory from `data/wave.npy` in a loop.
+The script loads the pre-built USD model from the submodule and plays the trajectory in a loop.
 
 ## Contact
 
-For any questions, please contact [support@wuji.tech](mailto:support@wuji.tech).
+For any questions, please contact support@wuji.tech.

--- a/run_sim.py
+++ b/run_sim.py
@@ -50,6 +50,7 @@ HAND_CFG = ArticulationCfg(
 
 
 def main():
+    """Set up scene with Wuji Hand and run trajectory tracking loop."""
     sim = sim_utils.SimulationContext(
         sim_utils.SimulationCfg(dt=1.0 / 100, device=args_cli.device)
     )


### PR DESCRIPTION
Related to: m-6873357980

## Summary

- Aligned README with Wuji repo style guide: replaced directory description table with `//` inline comments, refined summary, fixed contact boilerplate
- Aligned CHANGELOG with style guide: removed internal file paths, corrected verb tense to past tense, wrote from user perspective
- Added docstring to `main()` function

## Test Plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify CHANGELOG follows Keep a Changelog format
- [ ] Run `/wuji-style:repo-check` confirms PASS on README and CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了发布日志和项目说明文档，改进了功能描述的表述
  * 增强了代码文档，提高了代码可读性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->