### PR TITLE
docs: 修复 README 失效链接并恢复可用演示视频

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simulation demo for IsaacSim. This repository provides a minimal example for loa
 
 **Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Isaac Lab Simulation Example](https://docs.wuji.tech/docs/en/wuji-description/latest/related-repos/#42-isaac-lab-simulation-example) on Wuji Docs Center.**
 
-https://github.com/user-attachments/assets/2f58ad84-7ed6-46fe-94c1-b4148068bec3
+https://github.com/user-attachments/assets/3fffb009-f78a-4dda-93ed-94de20b93811
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Simulation demo for IsaacSim. This repository provides a minimal example for loading and controlling the Wuji Hand in IsaacSim simulator. Loads pre-built USD assets with PBR materials and plays trajectory in a loop, supporting both left- and right-hand configurations via `--side` argument.
 
-**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Wuji Hand Description Guide — Isaac Lab Simulation](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-description-guide/#332-isaac-lab-simulation-example) on Wuji Docs Center.**
+**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Isaac Lab Simulation Example](https://docs.wuji.tech/docs/en/wuji-description/latest/related-repos/#42-isaac-lab-simulation-example) on Wuji Docs Center.**
 
 https://github.com/user-attachments/assets/2f58ad84-7ed6-46fe-94c1-b4148068bec3
 


### PR DESCRIPTION
## Summary

- README 原链接指向文档中心已下线的 Wuji Hand Description Guide 页面（返回 404），改链到现行有效的 wuji-description 产品 Related Repositories 页 Isaac Lab Simulation Example 章节
- 当前演示视频资源对匿名访问者返回 404（页面上视频无法播放），暂时回退到上一版可正常访问的演示视频。**注意**：旧视频为 USD/PBR 改造（#22）之前录制，如有新版演示视频建议重新上传替换

## 自测结果

- 自测环境：WSL2 (Linux 6.6)，curl 带浏览器 UA 验证
- 新文档链接 https://docs.wuji.tech/docs/en/wuji-description/latest/related-repos/#42-isaac-lab-simulation-example 返回 200，锚点 id 已在渲染页面中核实存在
- 回退后的视频资源匿名访问返回 200，当前线上视频资源两次复测均 404
- README 中其余全部外链与 #quick-start 内部锚点逐一复检，均有效

🤖 Generated with [Claude Code](https://claude.com/claude-code)